### PR TITLE
Fix percona proxysql node selector

### DIFF
--- a/charts/shopware/templates/database.yaml
+++ b/charts/shopware/templates/database.yaml
@@ -79,11 +79,7 @@ spec:
       {{- with .Values.percona.proxy.resources }}
         {{- toYaml . | nindent 6 }}
       {{- end }}
-    nodeSelector:
-      {{- with .Values.percona.nodeSelector }}
-          {{- toYaml . | nindent 6 }}
-      {{- end }}
-
+    
     volumeSpec:
       persistentVolumeClaim:
         storageClassName: {{ .Values.percona.proxy.storageClassName | default "" | quote}}


### PR DESCRIPTION
The `nodeSelector` of the proxysql was declared twice with different values.