### PR TITLE
feat: add support for valkey

### DIFF
--- a/charts/shopware/Chart.lock
+++ b/charts/shopware/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 1.14.0
 - name: operator
   repository: https://shopware.github.io/helm-charts/
-  version: 0.0.12
+  version: 0.0.13
 - name: valkey
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 1.0.1
@@ -29,5 +29,5 @@ dependencies:
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
   version: 25.24.1
-digest: sha256:42803a87395b604500df7eff5c91a2733539a3049cb61fb61fe1bdd7f1a2b64c
-generated: "2024-10-03T10:24:00.488359+02:00"
+digest: sha256:32751636f3bf30936dfc68134e6418c4e4db50baa1eb6bc0722014e3735865d3
+generated: "2024-10-03T10:27:07.462536+02:00"

--- a/charts/shopware/Chart.lock
+++ b/charts/shopware/Chart.lock
@@ -8,6 +8,18 @@ dependencies:
 - name: valkey
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 1.0.1
+- name: valkey
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 1.0.1
+- name: valkey
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 1.0.1
+- name: redis
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 19.1.2
+- name: redis
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 19.1.2
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 19.1.2
@@ -17,5 +29,5 @@ dependencies:
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
   version: 25.24.1
-digest: sha256:65f40babc850033b47c251ec048e6091e2068a6b32c64932c198e5561bf0bbf7
-generated: "2024-10-01T16:13:07.498728+02:00"
+digest: sha256:42803a87395b604500df7eff5c91a2733539a3049cb61fb61fe1bdd7f1a2b64c
+generated: "2024-10-03T10:24:00.488359+02:00"

--- a/charts/shopware/Chart.lock
+++ b/charts/shopware/Chart.lock
@@ -5,12 +5,9 @@ dependencies:
 - name: operator
   repository: https://shopware.github.io/helm-charts/
   version: 0.0.12
-- name: redis
+- name: valkey
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 19.1.2
-- name: redis
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 19.1.2
+  version: 1.0.1
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 19.1.2
@@ -20,5 +17,5 @@ dependencies:
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
   version: 25.24.1
-digest: sha256:9f8300e7ed178c964186e350c058646a2e0466eaa65febe3545197440a5f11e2
-generated: "2024-09-04T13:55:02.853221638+02:00"
+digest: sha256:65f40babc850033b47c251ec048e6091e2068a6b32c64932c198e5561bf0bbf7
+generated: "2024-10-01T16:13:07.498728+02:00"

--- a/charts/shopware/Chart.yaml
+++ b/charts/shopware/Chart.yaml
@@ -35,6 +35,24 @@ dependencies:
     repository: https://shopware.github.io/helm-charts/
     condition: shopware-operator.enabled
 
+  - name: valkey
+    alias: valkeyapp
+    version: 1.0.1
+    repository: oci://registry-1.docker.io/bitnamicharts
+    condition: valkeyapp.enabled
+
+  - name: valkey
+    alias: valkeysession
+    version: 1.0.1
+    repository: oci://registry-1.docker.io/bitnamicharts
+    condition: valkeysession.enabled
+
+  - name: valkey
+    alias: valkeyworker
+    version: 1.0.1
+    repository: oci://registry-1.docker.io/bitnamicharts
+    condition: valkeyworker.enabled
+
   - name: redis
     alias: redisapp
     version: 19.1.2
@@ -48,10 +66,10 @@ dependencies:
     condition: redissession.enabled
 
   - name: redis
-    alias: redisqueue
+    alias: redisworker
     version: 19.1.2
     repository: oci://registry-1.docker.io/bitnamicharts
-    condition: redisqueue.enabled
+    condition: redisworker.enabled
 
   - name: grafana
     alias: grafana

--- a/charts/shopware/Chart.yaml
+++ b/charts/shopware/Chart.yaml
@@ -31,7 +31,7 @@ dependencies:
 
   - name: operator
     alias: shopware-operator
-    version: 0.0.12
+    version: 0.0.13
     repository: https://shopware.github.io/helm-charts/
     condition: shopware-operator.enabled
 

--- a/charts/shopware/README.md
+++ b/charts/shopware/README.md
@@ -27,7 +27,7 @@ loss that may occur.
 If you encounter any issues or have suggestions for improvements, please feel free to
 open an issue or contribute to the project.
 
-## Cluster Installation
+# Cluster Installation
 
 This Helm chart can be installed locally or within an existing Kubernetes cluster, using tools like ArgoCD.
 This guide focuses on a simple local installation to help you get started.

--- a/charts/shopware/templates/_helpers.tpl
+++ b/charts/shopware/templates/_helpers.tpl
@@ -65,6 +65,18 @@ secretAccessKeyRef:
 {{- end}}
 {{- end -}}
 
+{{ define "getValkeyAppMasterService" -}}
+{{ printf "%s-valkeyapp-master" .Release.Name }}
+{{- end -}}
+
+{{ define "getValkeySessionMasterService" -}}
+{{ printf "%s-valkeysession-master" .Release.Name }}
+{{- end -}}
+
+{{ define "getValkeyWorkerService" -}}
+{{ printf "%s-valkeyworker-master" .Release.Name }}
+{{- end -}}
+
 {{ define "getRedisAppMasterService" -}}
 {{ printf "%s-redisapp-master" .Release.Name }}
 {{- end -}}
@@ -73,8 +85,8 @@ secretAccessKeyRef:
 {{ printf "%s-redissession-master" .Release.Name }}
 {{- end -}}
 
-{{ define "getRedisReplicasService" -}}
-{{ printf "%s-redis-replicas" .Release.Name }}
+{{ define "getRedisWorkerService" -}}
+{{ printf "%s-redisworker-master" .Release.Name }}
 {{- end -}}
 
 {{ define "getOpenSearchClusterName" -}}

--- a/charts/shopware/templates/_helpers.tpl
+++ b/charts/shopware/templates/_helpers.tpl
@@ -65,28 +65,28 @@ secretAccessKeyRef:
 {{- end}}
 {{- end -}}
 
-{{ define "getValkeyAppMasterService" -}}
-{{ printf "%s-valkeyapp-master" .Release.Name }}
+{{ define "getSessionCacheMasterService" -}}
+{{- if .Values.valkeysession.enabled }}
+{{- printf "%s-valkeysession-master" .Release.Name }}
+{{- else }}
+{{- printf "%s-redissession-master" .Release.Name }}
+{{- end }}
 {{- end -}}
 
-{{ define "getValkeySessionMasterService" -}}
-{{ printf "%s-valkeysession-master" .Release.Name }}
+{{ define "getAppCacheMasterService" -}}
+{{- if .Values.valkeyapp.enabled }}
+{{- printf "%s-valkeyapp-master" .Release.Name }}
+{{- else }}
+{{- printf "%s-redisapp-master" .Release.Name }}
+{{- end }}
 {{- end -}}
 
-{{ define "getValkeyWorkerMasterService" -}}
-{{ printf "%s-valkeyworker-master" .Release.Name }}
-{{- end -}}
-
-{{ define "getRedisAppMasterService" -}}
-{{ printf "%s-redisapp-master" .Release.Name }}
-{{- end -}}
-
-{{ define "getRedisSessionMasterService" -}}
-{{ printf "%s-redissession-master" .Release.Name }}
-{{- end -}}
-
-{{ define "getRedisWorkerMasterService" -}}
-{{ printf "%s-redisworker-master" .Release.Name }}
+{{ define "getWorkerMasterService" -}}
+{{- if .Values.valkeyworker.enabled }}
+{{- printf "%s-valkeyworker-master" .Release.Name }}
+{{- else }}
+{{- printf "%s-redisworker-master" .Release.Name }}
+{{- end }}
 {{- end -}}
 
 {{ define "getOpenSearchClusterName" -}}

--- a/charts/shopware/templates/_helpers.tpl
+++ b/charts/shopware/templates/_helpers.tpl
@@ -73,7 +73,7 @@ secretAccessKeyRef:
 {{ printf "%s-valkeysession-master" .Release.Name }}
 {{- end -}}
 
-{{ define "getValkeyWorkerService" -}}
+{{ define "getValkeyWorkerMasterService" -}}
 {{ printf "%s-valkeyworker-master" .Release.Name }}
 {{- end -}}
 
@@ -85,7 +85,7 @@ secretAccessKeyRef:
 {{ printf "%s-redissession-master" .Release.Name }}
 {{- end -}}
 
-{{ define "getRedisWorkerService" -}}
+{{ define "getRedisWorkerMasterService" -}}
 {{ printf "%s-redisworker-master" .Release.Name }}
 {{- end -}}
 

--- a/charts/shopware/templates/database.yaml
+++ b/charts/shopware/templates/database.yaml
@@ -39,7 +39,7 @@ spec:
       {{- end }}
     volumeSpec:
       persistentVolumeClaim:
-        storageClassName: {{ .Values.percona.database.storageClassName | default "" | quote }}
+        storageClassName: {{ .Values.percona.database.storageClassName | quote }}
         resources:
           requests:
             storage: {{ .Values.percona.database.storageSize | default "30G" | quote }}

--- a/charts/shopware/templates/database.yaml
+++ b/charts/shopware/templates/database.yaml
@@ -42,7 +42,7 @@ spec:
         storageClassName: {{ .Values.percona.database.storageClassName | quote }}
         resources:
           requests:
-            storage: {{ .Values.percona.database.storageSize | default "30G" | quote }}
+            storage: {{ .Values.percona.database.storageSize | default "8Gi" | quote }}
     gracePeriod: 600
 
     # https://developer.shopware.com/docs/guides/hosting/performance/performance-tweaks.html

--- a/charts/shopware/templates/database.yaml
+++ b/charts/shopware/templates/database.yaml
@@ -39,7 +39,7 @@ spec:
       {{- end }}
     volumeSpec:
       persistentVolumeClaim:
-        storageClassName: {{ .Values.percona.database.storageClassName | default "" | quote }}
+        storageClassName: {{ .Values.percona.database.storageClassName | default "" }}
         resources:
           requests:
             storage: {{ .Values.percona.database.storageSize | default "8Gi" | quote }}

--- a/charts/shopware/templates/database.yaml
+++ b/charts/shopware/templates/database.yaml
@@ -39,7 +39,7 @@ spec:
       {{- end }}
     volumeSpec:
       persistentVolumeClaim:
-        storageClassName: {{ .Values.percona.database.storageClassName | quote }}
+        storageClassName: {{ .Values.percona.database.storageClassName | default "" | quote }}
         resources:
           requests:
             storage: {{ .Values.percona.database.storageSize | default "8Gi" | quote }}

--- a/charts/shopware/templates/store.yaml
+++ b/charts/shopware/templates/store.yaml
@@ -29,34 +29,25 @@ spec:
   {{- end }}
 
   sessionCache:
-    {{- if .Values.valkeysession.enabled }}
+    {{- if or .Values.valkeysession.enabled .Values.redissession.enabled}}
     adapter: redis
-    redisHost: {{ template "getValkeySessionMasterService" . }}
-    {{- else if .Values.redissession.enabled }}
-    adapter: redis
-    redisHost: {{ template "getRedisSessionMasterService" . }}
+    redisHost: {{ template "getSessionCacheMasterService" . }}
     {{- else }}
     adapter: builtin
     {{- end }}
 
   appCache:
-    {{- if .Values.valkeyapp.enabled }}
+    {{- if or .Values.valkeyapp.enabled .Values.redisapp.enabled }}
     adapter: redis
-    redisHost: {{ template "getValkeyAppMasterService" . }}
-    {{- else if .Values.redisapp.enabled }}
-    adapter: redis
-    redisHost: {{ template "getRedisAppMasterService" . }}
+    redisHost: {{ template "getAppCacheMasterService" . }}
     {{- else }}
     adapter: builtin
     {{- end }}
 
   worker:
-    {{- if .Values.valkeyworker.enabled }}
+    {{- if or .Values.valkeyworker.enabled .Values.redisworker.enabled}}
     adapter: redis
-    redisHost: {{ template "getValkeyWorkerMasterService" . }}
-    {{- else if .Values.redisworker.enabled }}
-    adapter: redis
-    redisHost: {{ template "getRedisWorkerMasterService" . }}
+    redisHost: {{ template "getWorkerMasterService" . }}
     {{- else }}
     adapter: builtin
     {{- end }}

--- a/charts/shopware/templates/store.yaml
+++ b/charts/shopware/templates/store.yaml
@@ -29,19 +29,38 @@ spec:
   {{- end }}
 
   sessionCache:
-    {{- if .Values.redissession.enabled }}
+    {{- if .Values.valkeysession.enabled }}
+    adapter: redis
+    redisHost: {{ template "getValkeySessionMasterService" . }}
+    {{- else if .Values.redissession.enabled }}
     adapter: redis
     redisHost: {{ template "getRedisSessionMasterService" . }}
     {{- else }}
     adapter: builtin
     {{- end }}
+
   appCache:
-    {{- if .Values.redisapp.enabled }}
+    {{- if .Values.valkeyapp.enabled }}
+    adapter: redis
+    redisHost: {{ template "getValkeyAppMasterService" . }}
+    {{- else if .Values.redisapp.enabled }}
     adapter: redis
     redisHost: {{ template "getRedisAppMasterService" . }}
     {{- else }}
     adapter: builtin
     {{- end }}
+
+  worker:
+    {{- if .Values.valkeyworker.enabled }}
+    adapter: redis
+    redisHost: {{ template "getValkeyWorkerService" . }}
+    {{- else if .Values.redisworker.enabled }}
+    adapter: redis
+    redisHost: {{ template "getRedisWorkerMasterService" . }}
+    {{- else }}
+    adapter: builtin
+    {{- end }}
+
 
   {{- if hasKey .Values.store "otel" }}
   {{- if hasKey .Values.store.otel "exporterEndpoint" }}

--- a/charts/shopware/templates/store.yaml
+++ b/charts/shopware/templates/store.yaml
@@ -53,14 +53,13 @@ spec:
   worker:
     {{- if .Values.valkeyworker.enabled }}
     adapter: redis
-    redisHost: {{ template "getValkeyWorkerService" . }}
+    redisHost: {{ template "getValkeyWorkerMasterService" . }}
     {{- else if .Values.redisworker.enabled }}
     adapter: redis
     redisHost: {{ template "getRedisWorkerMasterService" . }}
     {{- else }}
     adapter: builtin
     {{- end }}
-
 
   {{- if hasKey .Values.store "otel" }}
   {{- if hasKey .Values.store.otel "exporterEndpoint" }}

--- a/charts/shopware/values.yaml
+++ b/charts/shopware/values.yaml
@@ -31,8 +31,8 @@ percona:
     # annotations:
     # affinity:
     # serviceAnnotations:
-    # storageClassName:
-    # storageSize: 8Gi
+    # storageClassName: standard
+    storageSize: 8Gi
 
     # We overwrite the topologySpreadConstraints for this to schedule only one database
     topologySpreadConstraints:
@@ -243,9 +243,11 @@ minio:
 opensearch:
   enabled: false
 
-redissession:
-  enabled: false
+valkeyapp:
+  enabled: true
   architecture: standalone
+  replica:
+    replicaCount: 1
   master:
     resources:
       requests:
@@ -254,12 +256,46 @@ redissession:
       limits:
         memory: 1Gi
         cpu: 1000m
+  auth:
+    enabled: false
+
+valkeysession:
+  enabled: true
+  architecture: standalone
+  replica:
+    replicaCount: 1
+  master:
+    resources:
+      requests:
+        memory: 500Mi
+        cpu: 1000m
+      limits:
+        memory: 1Gi
+        cpu: 1000m
+  auth:
+    enabled: false
+
+valkeyworker:
+  enabled: false
+  architecture: standalone
+  replica:
+    replicaCount: 1
+  master:
+    resources:
+      requests:
+        memory: 500Mi
+        cpu: 1000m
+      limits:
+        memory: 1Gi
+        cpu: 2000m
   auth:
     enabled: false
 
 redisapp:
-  enabled: true
+  enabled: false
   architecture: standalone
+  replica:
+    replicaCount: 1
   master:
     resources:
       requests:
@@ -271,9 +307,27 @@ redisapp:
   auth:
     enabled: false
 
-redisqueue:
+redissession:
   enabled: false
   architecture: standalone
+  replica:
+    replicaCount: 1
+  master:
+    resources:
+      requests:
+        memory: 500Mi
+        cpu: 1000m
+      limits:
+        memory: 1Gi
+        cpu: 1000m
+  auth:
+    enabled: false
+
+redisworker:
+  enabled: false
+  architecture: standalone
+  replica:
+    replicaCount: 1
   master:
     resources:
       requests:

--- a/charts/shopware/values.yaml
+++ b/charts/shopware/values.yaml
@@ -31,8 +31,8 @@ percona:
     # annotations:
     # affinity:
     # serviceAnnotations:
-    # storageClassName: standard
-    storageSize: 8Gi
+    # storageClassName:
+    # storageSize: 8Gi
 
     # We overwrite the topologySpreadConstraints for this to schedule only one database
     topologySpreadConstraints:
@@ -276,7 +276,7 @@ valkeysession:
     enabled: false
 
 valkeyworker:
-  enabled: false
+  enabled: true
   architecture: standalone
   replica:
     replicaCount: 1
@@ -293,51 +293,51 @@ valkeyworker:
 
 redisapp:
   enabled: false
-  architecture: standalone
-  replica:
-    replicaCount: 1
-  master:
-    resources:
-      requests:
-        memory: 500Mi
-        cpu: 1000m
-      limits:
-        memory: 1Gi
-        cpu: 1000m
-  auth:
-    enabled: false
+  # architecture: standalone
+  # replica:
+  #   replicaCount: 1
+  # master:
+  #   resources:
+  #     requests:
+  #       memory: 500Mi
+  #       cpu: 1000m
+  #     limits:
+  #       memory: 1Gi
+  #       cpu: 1000m
+  # auth:
+  #   enabled: false
 
 redissession:
   enabled: false
-  architecture: standalone
-  replica:
-    replicaCount: 1
-  master:
-    resources:
-      requests:
-        memory: 500Mi
-        cpu: 1000m
-      limits:
-        memory: 1Gi
-        cpu: 1000m
-  auth:
-    enabled: false
+  # architecture: standalone
+  # replica:
+  #   replicaCount: 1
+  # master:
+  #   resources:
+  #     requests:
+  #       memory: 500Mi
+  #       cpu: 1000m
+  #     limits:
+  #       memory: 1Gi
+  #       cpu: 1000m
+  # auth:
+  #   enabled: false
 
 redisworker:
   enabled: false
-  architecture: standalone
-  replica:
-    replicaCount: 1
-  master:
-    resources:
-      requests:
-        memory: 500Mi
-        cpu: 1000m
-      limits:
-        memory: 1Gi
-        cpu: 2000m
-  auth:
-    enabled: false
+  # architecture: standalone
+  # replica:
+  #   replicaCount: 1
+  # master:
+  #   resources:
+  #     requests:
+  #       memory: 500Mi
+  #       cpu: 1000m
+  #     limits:
+  #       memory: 1Gi
+  #       cpu: 2000m
+  # auth:
+  #   enabled: false
 
 # blackfire:
   # serverID: <your id>


### PR DESCRIPTION
- Intentionally update the storage size for the Percona database to 8Gi for dev and let users increase it in case they want to use it in prod.
- Fix the Percona database storageClass to enable default storage in the cluster.
- Fix worker config to enable passing in Redis, Valkey, or use the built-in option.
