### PR TITLE
feat: add setupscripts and remove hooks

### DIFF
--- a/charts/shopware/Chart.yaml
+++ b/charts/shopware/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.15
+version: 0.0.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.15"
+appVersion: "0.0.16"
 
 dependencies:
   - name: pxc-operator
@@ -31,7 +31,7 @@ dependencies:
 
   - name: operator
     alias: shopware-operator
-    version: 0.0.20
+    version: 0.0.21
     repository: https://shopware.github.io/helm-charts/
     condition: shopware-operator.enabled
 

--- a/charts/shopware/templates/store.yaml
+++ b/charts/shopware/templates/store.yaml
@@ -80,10 +80,12 @@ spec:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 
-  setupHook:
-    {{- with .Values.store.setupHook }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
+  {{- if hasKey .Values.store "setupScript" }}
+  setupScript: {{ .Values.store.setupScript | toYaml | indent 2 }}
+  {{- end }}
+  {{- if hasKey .Values.store "migrationScript" }}
+  migrationScript: {{ .Values.store.migrationScript | toYaml | indent 2 }}
+  {{- end }}
 
   {{- if hasKey .Values.store "adminCredentials" }}
   adminCredentials:

--- a/charts/shopware/values.yaml
+++ b/charts/shopware/values.yaml
@@ -189,21 +189,25 @@ store:
     ingressClassName: nginx
     # annotations:
 
-  # You can run commands before and after the /setup is executed.
-  # The commands will be chained like this: <before> /setup <after>
-  # So make sure to add a `;` for execute always or `&&` for chaining and exit if error
-  # occurs.
-  # setupHook:
-  #   before: |
-  #     echo This is a command before setup will executed;
-  #   after: |
-  #     ; echo This is a command after setup is executed;
-  #     ps -ef | grep 'fluent-bit' | grep -v kill | grep -v grep | awk '{print $2}' | xargs -r kill -15
-  #     true;
+  # You have the option to run commands both before and after the /setup command is executed.
+  # If you wish to run the default setup script included in the official Shopware Docker image,
+  # ensure that the /setup command is invoked.
+  # In case the /setup command fails, it is crucial to exit the process with an appropriate
+  # error code. Failing to provide an error code will result in the job being marked as
+  # successful, even though the store may be in a non-functional state.
+  # setupScript: |
+  #   echo "Execute setup script from paas backend"
+  #   /setup
+  #   if [ $? -eq 0 ]; then
+  #       echo "Setup Finished"
+  #   else
+  #       echo "Setup Failed: exit with 20"
+  #       exit 20
+  #   fi
 
-  # migrationHook:
-  #   before: echo This is a command before migration will executed;
-  #   after: echo This is a command after migration is executed;
+  # You can also change the migration script in the same format as the setup script
+  # The default is /setup
+  # migrationScript: /setup
 
   # Dynamic is the default here. If you are more experience user then change these values as you like.
   # fpm:


### PR DESCRIPTION
The new operator supports only scripts and hooks are deprecated. We had
several issues and attempts to make it work with hooks but they are
feeling kind of hacky. So we provide a possiblity to overwrite the
command completely and let the user decide what to do, if a setup is
crashing or when it should crash.
