### PR TITLE
Replaced x-request-id by the correct header, x-trace-id

### DIFF
--- a/charts/shopware/Chart.yaml
+++ b/charts/shopware/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.20
+version: 0.0.21
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.20"
+appVersion: "0.0.21"
 
 dependencies:
   - name: pxc-operator

--- a/charts/shopware/templates/store_caddy_config.yaml
+++ b/charts/shopware/templates/store_caddy_config.yaml
@@ -21,12 +21,13 @@ data:
     log
 {{- end }}
     route {
-      header {
-        X-Request-Id {http.request.header.x-request-id}
-      }
       tracing {
         span caddy
       }
+      header {
+       X-Trace-Id {http.vars.trace_id}
+      }
+      request_header X-Trace-Id {http.vars.trace_id}
       @default {
         not path /theme/* /media/* /thumbnail/* /bundles/* /sitemap/*
       }


### PR DESCRIPTION
This PR removes the usage of `x-request-id` and use `x-trace-id`.