### PR TITLE
Grafana ingress

### DIFF
--- a/charts/shopware/Chart.yaml
+++ b/charts/shopware/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.25
+version: 0.0.26
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.25"
+appVersion: "0.0.26"
 
 dependencies:
   - name: pxc-operator

--- a/charts/shopware/templates/istio.yaml
+++ b/charts/shopware/templates/istio.yaml
@@ -7,6 +7,17 @@ spec:
   mtls:
     mode: STRICT
 ---
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: disable-mtls-prometheus
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  mtls:
+    mode: DISABLE
+---
 # https://github.com/kubernetes/ingress-nginx/issues/3171
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService

--- a/charts/shopware/values.yaml
+++ b/charts/shopware/values.yaml
@@ -525,6 +525,8 @@ otel-collector:
 
 grafana:
   enabled: false
+  podAnnotations:
+    sidecar.istio.io/inject: 'false'
   datasources:
     datasources.yaml:
       apiVersion: 1


### PR DESCRIPTION
This PR does the following to allow Grafana ingress to work:
- Disable Istio side car injection for Grafana.
- Exclude Prometheus from mTLS strict auth policy.