### PR TITLE
Add e2e tests for shopware chart

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,10 +9,9 @@ permissions:
   # Optional: allow write access to checks to allow the action to annotate code in the PR.
   checks: write
 
-
 jobs:
   CheckVersionUpdate:
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=sw-amd64/cpu=1
     container: "ghcr.io/shopware-redstone/k8s-tooling-image:latest"
     steps:
       - name: Checkout
@@ -47,17 +46,70 @@ jobs:
             exit 11
           fi
 
-  # Not working because of lookups
-  # lint-chart:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: 0
-  #     - name: Setup Helm
-  #       uses: azure/setup-helm@v4
-  #       with:
-  #         version: v3.15.3
-  #     - name: Lint Helm chart
-  #       run: helm lint charts/shopware
+  helm-lint:
+    name: helm lint
+    runs-on: runs-on=${{ github.run_id }}/runner=sw-amd64/cpu=1
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: Set up Helm
+        uses: azure/setup-helm@v4.2.0
+        with:
+          version: v3.16.4
+      - name: helm lint
+        run: |
+          helm lint charts/shopware
+
+  test-on-cluster:
+    name: Cluster E2E Test
+    runs-on: runs-on=${{ github.run_id }}/runner=sw-amd64/cpu=4
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4.2.0
+        with:
+          version: v3.16.4
+
+      - name: Create k8s Kind Cluster
+        uses: helm/kind-action@v1
+
+      - name: Run chart-testing (install)
+        run: |
+          kubectl apply -k "github.com/minio/operator?ref=v5.0.15"
+          kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/baremetal/deploy.yaml
+          kubectl create namespace test
+          kubectl rollout status --namespace ingress-nginx deployment/ingress-nginx-controller --timeout=60s
+
+          helm repo add percona https://percona.github.io/percona-helm-charts
+          helm repo add grafana https://grafana.github.io/helm-charts
+          helm repo add prometheus https://prometheus-community.github.io/helm-charts
+          helm repo add shopware https://shopware.github.io/helm-charts
+          helm repo add opentelemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+          helm dependency build charts/shopware
+
+          helm install test --namespace test charts/shopware --set minio.storageSize=100Mi --set minio.resources.requests.cpu=100m
+
+          kubectl wait --namespace test --for=condition=Available --timeout=60s deployment/shopware-operator || {
+            kubectl get deployment/shopware-operator --namespace test -o json && exit 2
+          }
+          kubectl wait --namespace test store/test --for='jsonpath={.status.state}'=setup --timeout=1m
+
+          kubectl wait --namespace test tenant/test-minio --for='jsonpath={.status.currentState}'=Initialized --timeout=1m || {
+            kubectl get tenant/test-minio --namespace test -o json; \
+            kubectl get pod/test-minio-pool-0-0 --namespace test -o json && exit 3
+          }
+
+          kubectl wait --namespace test jobs/test-setup --timeout=3m --for=condition=complete || {
+            kubectl get job/test-setup --namespace test -o json && exit 4
+          }
+
+          kubectl wait --namespace test store/test --for='jsonpath={.status.state}'=ready --timeout=20s || {
+            kubectl get store/test --namespace test -o json && exit 5
+          }
+
+          kubectl get pods --namespace test -o wide

--- a/charts/shopware/Chart.yaml
+++ b/charts/shopware/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.30
+version: 0.0.31
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.30"
+appVersion: "0.0.31"
 
 dependencies:
   - name: pxc-operator

--- a/charts/shopware/templates/tenant.yaml
+++ b/charts/shopware/templates/tenant.yaml
@@ -29,6 +29,12 @@ spec:
     - servers: 4
       name: pool-0
       volumesPerServer: 2
+      {{- if hasKey .Values.minio "resources" }}
+      resources:
+        {{- with .Values.minio.resources }}
+            {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- else }}
       resources:
         limits:
           cpu: 1000m
@@ -36,6 +42,7 @@ spec:
         requests:
           cpu: 1000m
           memory: 2Gi
+      {{- end }}
       volumeClaimTemplate:
         metadata:
           name: data

--- a/charts/shopware/templates/tenant_secret.yaml
+++ b/charts/shopware/templates/tenant_secret.yaml
@@ -22,14 +22,6 @@ stringData:
   config.env: |-
     export MINIO_ROOT_USER="{{ .Values.minio.rootUser | default "admin" }}"
     export MINIO_ROOT_PASSWORD="{{- template "generatePassword" }}"
-{{ else }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: minio-configuration
-type: Opaque
-data:
-  config.env: {{ index (lookup "v1" "Secret" .Release.Namespace "minio-configuration").data "config.env" }}
 {{ end }}
 {{ end }}
 {{ end }}

--- a/charts/shopware/templates/tenant_user.yaml
+++ b/charts/shopware/templates/tenant_user.yaml
@@ -1,19 +1,6 @@
 {{ if hasKey .Values "minio" }}
 {{ if .Values.minio.enabled | default false }}
 ---
-#
-# {{- $ak := include "getTenantUserAccessKeyName" . -}}
-# {{- $sk := include "getTenantUserSecretAccessKeyName" . -}}
-# {{- $secret := include "getTenantUserSecretName" . -}}
-# apiVersion: v1
-# data:
-# {{- if .Release.IsInstall }}
-#   {{ $ak }}: {{ template "generatePasswordEncoded" }}
-#   {{ $sk }}: {{ template "generatePasswordEncoded" }}
-# {{ else }}
-#   {{ $ak }}: {{ index (lookup "v1" "Secret" .Release.Namespace $secret).data $ak }}
-#   {{ $sk }}: {{ index (lookup "v1" "Secret" .Release.Namespace $secret).data $sk }}
-# {{ end }}
 kind: Secret
 apiVersion: v1
 metadata:

--- a/charts/shopware/values.yaml
+++ b/charts/shopware/values.yaml
@@ -121,7 +121,7 @@ store:
   #   exporterEndpoint: http://opentelemetry-collector.opentelemetry-collector.svc.cluster.local:4317
 
   database:
-    user: 'root'
+    user: "root"
     # version: '8'
     # port: 3306
     # name: 'shopware'
@@ -281,6 +281,13 @@ minio:
   # When using Istio, the image must include curl; hence, we use minio/mc.
   # For non-Istio installations, the client image can be minio/mc.
   # clientImage: minio/mc
+  # resources:
+  #   requests:
+  #     memory: 2Gi
+  #     cpu: 1000m
+  #   limits:
+  #     memory: 2Gi
+  #     cpu: 1000m
 
   # This configuration sets the username and password for MinIO login.
   # If the password is not specified, it will be automatically generated.
@@ -396,17 +403,17 @@ redisworker:
   #   enabled: false
 
 # blackfire:
-  # serverID: <your id>
-  # serverToken: <your token>
-  # image: blackfire/blackfire:2
-  # port: 8307
-  # resources:
-  #   requests:
-  #     memory: 100Mi
-  #     cpu: 100m
-  #   limits:
-  #     memory: 100Mi
-  #     cpu: 100m
+# serverID: <your id>
+# serverToken: <your token>
+# image: blackfire/blackfire:2
+# port: 8307
+# resources:
+#   requests:
+#     memory: 100Mi
+#     cpu: 100m
+#   limits:
+#     memory: 100Mi
+#     cpu: 100m
 
 # Percona has currently only AMD images, so we make sure with a mixed cluster that we
 # use the AMD clusters.
@@ -526,7 +533,7 @@ otel-collector:
 grafana:
   enabled: false
   podAnnotations:
-    sidecar.istio.io/inject: 'false'
+    sidecar.istio.io/inject: "false"
   datasources:
     datasources.yaml:
       apiVersion: 1
@@ -539,14 +546,14 @@ grafana:
           type: loki
           url: http://loki-gateway.loki.svc.cluster.local
           jsonData:
-            httpHeaderName1: 'X-Scope-OrgID'
+            httpHeaderName1: "X-Scope-OrgID"
           secureJsonData:
             httpHeaderValue1: tenant-{{ .Release.Namespace }}
         - name: Tempo
           type: tempo
           url: http://tempo.tempo.svc.cluster.local
           jsonData:
-            httpHeaderName1: 'X-Scope-OrgID'
+            httpHeaderName1: "X-Scope-OrgID"
           secureJsonData:
             httpHeaderValue1: tenant-{{ .Release.Namespace }}
 


### PR DESCRIPTION
This will add tests in the pipeline.
Helm lint is now executed, I needed to change some code for that in the minio resources.
The default for minio cpu limits are 1 core, so I needed to template this for the pipeline.
The pipeline is spinning up a kind cluster and executes a helm install with minimal change so we always make sure that a pr is working as expected with the default resources.