### PR TITLE
Add rights for fastly operator

### DIFF
--- a/.github/chainguard/shopware-fasly.sts.yaml
+++ b/.github/chainguard/shopware-fasly.sts.yaml
@@ -1,0 +1,7 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: repo:shopware\/fastly-operator:ref:refs\/tags\/.*
+
+permissions:
+  contents: write
+  issues: write
+  pull_requests: write


### PR DESCRIPTION
This adds rights for the fastly-operator to create a pr for updateing the helm chart
