### PR TITLE
Remove unsupported log format parameter from Caddyfile

### DIFF
--- a/charts/shopware/templates/store_caddy_config.yaml
+++ b/charts/shopware/templates/store_caddy_config.yaml
@@ -12,7 +12,6 @@ data:
       format json
 
       output file {{ include "caddyLogPath" . }} {
-        format json
         roll_size 10MB
         roll_keep 5
         roll_keep_for 24h


### PR DESCRIPTION
The new version from Caddy does not suport format parameter in the log output block