### PR TITLE
Send sitemap request directly to shopware

### DIFF
--- a/charts/shopware/Chart.yaml
+++ b/charts/shopware/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.38
+version: 0.0.39
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.38"
+appVersion: "0.0.39"
 
 dependencies:
   - name: pxc-operator

--- a/charts/shopware/templates/store_caddy_config.yaml
+++ b/charts/shopware/templates/store_caddy_config.yaml
@@ -29,7 +29,7 @@ data:
       }
       request_header X-Trace-Id {http.vars.trace_id}
       @default {
-        not path /theme/* /media/* /thumbnail/* /bundles/* /sitemap/*
+        not path /theme/* /media/* /thumbnail/* /bundles/*
       }
       root * /var/www/html/public
       php_fastcgi @default unix//tmp/php-fpm.sock {


### PR DESCRIPTION
This pull request includes a small change to the `store_caddy_config.yaml` file. The change removes `/sitemap/*` from the `not path` condition in the `@default` block, allowing requests to `/sitemap/*` to be handled differently.