### PR TITLE
Made Caddy timeout configurable

### DIFF
--- a/charts/shopware/Chart.yaml
+++ b/charts/shopware/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.39
+version: 0.0.40
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.39"
+appVersion: "0.0.40"
 
 dependencies:
   - name: pxc-operator

--- a/charts/shopware/templates/store_caddy_config.yaml
+++ b/charts/shopware/templates/store_caddy_config.yaml
@@ -34,8 +34,8 @@ data:
       root * /var/www/html/public
       php_fastcgi @default unix//tmp/php-fpm.sock {
         trusted_proxies private_ranges
-        read_timeout 30s
-        write_timeout 30s
+        read_timeout {{ .Values.store.caddy.readTimeout }}
+        write_timeout {{ .Values.store.caddy.writeTimeout }}
       }
       encode gzip
       file_server

--- a/charts/shopware/values.yaml
+++ b/charts/shopware/values.yaml
@@ -87,6 +87,12 @@ store:
   # remove this if you do not want to use a service account
   serviceAccountName: store-sa
 
+  caddy:
+    # This is the read timeout for the caddy server. Default is 60s.
+    readTimeout: 60s
+    # This is the write timeout for the caddy server. Default is 60s.
+    writeTimeout: 60s
+    
   cdnURL: "example.com"
 
   # Shop settings can be configured at any time using the deployment helper.


### PR DESCRIPTION
This pull request updates the chart version and introduces configurable timeout settings for the Caddy server in the Shopware Helm chart. These changes enhance flexibility and maintainability for deployments.

### Version Updates:
* Updated `version` and `appVersion` in `charts/shopware/Chart.yaml` from `0.0.39` to `0.0.40` to reflect the new chart and application version.

### Configuration Enhancements:
* Made the Caddy server's `read_timeout` and `write_timeout` configurable by replacing hardcoded values in `charts/shopware/templates/store_caddy_config.yaml` with Helm template variables (`.Values.store.caddy.readTimeout` and `.Values.store.caddy.writeTimeout`).
* Added default values for `readTimeout` and `writeTimeout` (both set to `60s`) under the new `store.caddy` section in `charts/shopware/values.yaml`. This allows users to customize these timeouts in their deployments.