### PR TITLE
feat: Added pod labels configuration

### DIFF
--- a/charts/shopware-operator/templates/deployment.yaml
+++ b/charts/shopware-operator/templates/deployment.yaml
@@ -33,6 +33,9 @@ spec:
         {{- end }}
       labels:
         control-plane: shopware-operator
+        {{- with .Values.podLabels }}
+            {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- if hasKey .Values "affinity" }}
       affinity:

--- a/charts/shopware-operator/values.yaml
+++ b/charts/shopware-operator/values.yaml
@@ -82,6 +82,7 @@ tolerations: []
 #           values:
 #           - linux
 
+podLabels: {}
 labels: {}
 podAnnotations: {}
 


### PR DESCRIPTION
This pull request introduces changes to enhance the configurability of the `shopware-operator` Helm chart by adding support for custom pod labels. The changes primarily focus on enabling users to define pod-specific labels through the chart's values file.

### Enhancements to configurability:

* [`charts/shopware-operator/templates/deployment.yaml`](diffhunk://#diff-b26419a9cdf844376e6cccddd6ac0b91ae55aa9f22aae7737ae143007e7973f8R36-R38): Added support for custom pod labels by incorporating the `podLabels` field from the values file and rendering it using `toYaml`.
* [`charts/shopware-operator/values.yaml`](diffhunk://#diff-641d96852640abd38d9ac5c03a7989aad994963de4fc69f2d0a8e49b3884d8e4R85): Introduced a new `podLabels` field in the values file, allowing users to specify custom labels for pods.