### PR TITLE
feat: only generate minio istio artifacts when its enabled

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,6 +110,8 @@ jobs:
             kubectl get pod/test-minio-pool-0-0 --namespace test -o json && exit 3
           }
 
+          sleep 10
+
           kubectl wait --namespace test jobs/test-setup --timeout=8m --for=condition=complete || {
             kubectl get job/test-setup --namespace test -o json; \
             kubectl get job --namespace test -o wide; \

--- a/charts/shopware/Chart.yaml
+++ b/charts/shopware/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.45
+version: 0.0.46
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.45"
+appVersion: "0.0.46"
 
 dependencies:
   - name: pxc-operator

--- a/charts/shopware/templates/istio.yaml
+++ b/charts/shopware/templates/istio.yaml
@@ -20,38 +20,6 @@ spec:
   mtls:
     mode: DISABLE
 ---
-# https://github.com/kubernetes/ingress-nginx/issues/3171
-apiVersion: networking.istio.io/v1beta1
-kind: VirtualService
-metadata:
-  name: minio
-  namespace: '{{ .Release.Namespace }}'
-spec:
-  hosts:
-    - minio.{{ .Release.Namespace }}.svc.cluster.local
-  http:
-    - match:
-        - port: 80
-          headers:
-            x-forwarded-host:
-              exact: {{ template "generateS3URLApi" . }}
-      route:
-        - destination:
-            host: minio.{{ .Release.Namespace }}.svc.cluster.local
-            port:
-              number: 80
-          headers:
-            request:
-              set:
-                Host:  {{ template "generateS3URLApi" . }}
-    - match:
-        - port: 80
-      route:
-        - destination:
-            host: minio.{{ .Release.Namespace }}.svc.cluster.local
-            port:
-              number: 80
----
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
@@ -72,38 +40,6 @@ spec:
             request:
               set:
                 Host: {{ .Values.applicationName}}.{{ .Values.projectName }}.{{ .Values.organizationName }}.{{ .Values.baseDomain }}
----
-apiVersion: networking.istio.io/v1beta1
-kind: DestinationRule
-metadata:
-  name: minio
-  namespace: '{{ .Release.Namespace }}'
-spec:
-  host: minio.{{ .Release.Namespace }}.svc.cluster.local
-  trafficPolicy:
-    outlierDetection:
-      consecutive5xxErrors: 100
-      interval: 1s
-      baseEjectionTime: 1m
-    loadBalancer:
-      localityLbSetting:
-        enabled: true
-        distribute:
-        - from: {{ .Values.region }}/{{ .Values.region }}a/*
-          to:
-            "{{ .Values.region }}/{{ .Values.region}}a/*": 80
-            "{{ .Values.region }}/{{ .Values.region}}b/*": 10
-            "{{ .Values.region }}/{{ .Values.region}}c/*": 10
-        - from: {{ .Values.region }}/{{ .Values.region }}b/*
-          to:
-            "{{ .Values.region }}/{{ .Values.region}}a/*": 10
-            "{{ .Values.region }}/{{ .Values.region}}b/*": 80
-            "{{ .Values.region }}/{{ .Values.region}}c/*": 10
-        - from: {{ .Values.region }}/{{ .Values.region }}c/*
-          to:
-            "{{ .Values.region }}/{{ .Values.region}}a/*": 10
-            "{{ .Values.region }}/{{ .Values.region}}b/*": 10
-            "{{ .Values.region }}/{{ .Values.region}}c/*": 80
 ---
 apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
@@ -136,4 +72,71 @@ spec:
               "{{ .Values.region }}/{{ .Values.region}}a/*": 10
               "{{ .Values.region }}/{{ .Values.region}}b/*": 10
               "{{ .Values.region }}/{{ .Values.region}}c/*": 80
+---
+{{ end }}
+
+{{ if and .Values.useIstio .Values.minio.enabled }}
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: minio
+  namespace: '{{ .Release.Namespace }}'
+spec:
+  hosts:
+    - minio.{{ .Release.Namespace }}.svc.cluster.local
+  http:
+    - match:
+        - port: 80
+          headers:
+            x-forwarded-host:
+              exact: {{ template "generateS3URLApi" . }}
+      route:
+        - destination:
+            host: minio.{{ .Release.Namespace }}.svc.cluster.local
+            port:
+              number: 80
+          headers:
+            request:
+              set:
+                Host:  {{ template "generateS3URLApi" . }}
+    - match:
+        - port: 80
+      route:
+        - destination:
+            host: minio.{{ .Release.Namespace }}.svc.cluster.local
+            port:
+              number: 80
+---
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: minio
+  namespace: '{{ .Release.Namespace }}'
+spec:
+  host: minio.{{ .Release.Namespace }}.svc.cluster.local
+  trafficPolicy:
+    outlierDetection:
+      consecutive5xxErrors: 100
+      interval: 1s
+      baseEjectionTime: 1m
+    loadBalancer:
+      localityLbSetting:
+        enabled: true
+        distribute:
+        - from: {{ .Values.region }}/{{ .Values.region }}a/*
+          to:
+            "{{ .Values.region }}/{{ .Values.region}}a/*": 80
+            "{{ .Values.region }}/{{ .Values.region}}b/*": 10
+            "{{ .Values.region }}/{{ .Values.region}}c/*": 10
+        - from: {{ .Values.region }}/{{ .Values.region }}b/*
+          to:
+            "{{ .Values.region }}/{{ .Values.region}}a/*": 10
+            "{{ .Values.region }}/{{ .Values.region}}b/*": 80
+            "{{ .Values.region }}/{{ .Values.region}}c/*": 10
+        - from: {{ .Values.region }}/{{ .Values.region }}c/*
+          to:
+            "{{ .Values.region }}/{{ .Values.region}}a/*": 10
+            "{{ .Values.region }}/{{ .Values.region}}b/*": 10
+            "{{ .Values.region }}/{{ .Values.region}}c/*": 80
 {{ end }}


### PR DESCRIPTION
This PR refactors the Istio configuration to ensure that Minio's Istio resources are only created when both Istio and Minio are enabled. This PR also fixes the E2E tests.