### PR TITLE
feat: disable automounting the service account token

### DIFF
--- a/charts/shopware/Chart.yaml
+++ b/charts/shopware/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.46
+version: 0.0.47
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.46"
+appVersion: "0.0.47"
 
 dependencies:
   - name: pxc-operator

--- a/charts/shopware/templates/service_account.yaml
+++ b/charts/shopware/templates/service_account.yaml
@@ -8,4 +8,5 @@ metadata:
   annotations:
     {{- toYaml .Values.serviceAccountAnnotations | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: {{ .Values.store.automountServiceAccountToken | default false }}
 {{- end }}

--- a/charts/shopware/values.yaml
+++ b/charts/shopware/values.yaml
@@ -78,6 +78,8 @@ store:
   # The name of the service account to use for the store deployments.
   # remove this if you do not want to use a service account
   serviceAccountName: store-sa
+  # Disables mounting the kubernetes service account token
+  automountServiceAccountToken: false
 
   caddy:
     # This is the read timeout for the caddy server. Default is 60s.


### PR DESCRIPTION
This pull request introduces a new configuration option to control whether the Kubernetes service account token is automatically mounted for the store deployment, and increments the chart and application versions accordingly.

Configuration enhancements:

* Added a new `automountServiceAccountToken` option under the `store` section in `values.yaml` to allow disabling the automatic mounting of the Kubernetes service account token. Default is set to `false`.
* Updated the `service_account.yaml` template to use the new `automountServiceAccountToken` value, defaulting to `false` if not specified.

Version updates:

* Bumped the chart version and application version from `0.0.46` to `0.0.47` in `Chart.yaml` to reflect the new changes.