### PR TITLE
feat: add support for scheduledTaskLabels in the store resource.

### DIFF
--- a/charts/shopware/Chart.yaml
+++ b/charts/shopware/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.57
+version: 0.0.58
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.57"
+appVersion: "0.0.58"
 
 dependencies:
   - name: pxc-operator

--- a/charts/shopware/templates/store.yaml
+++ b/charts/shopware/templates/store.yaml
@@ -99,6 +99,10 @@ spec:
   scheduledTask:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.store.scheduledTaskLabels }}
+  scheduledTaskLabels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 
   fpm:
     {{- if hasKey .Values.store "fpm" }}


### PR DESCRIPTION
This pull request adds support for specifying custom labels for scheduled tasks in the Helm chart's `store.yaml` template. This allows users to define `scheduledTaskLabels` via values, which will be included in the generated manifest.

Helm chart templating:

* Added a `scheduledTaskLabels` section to the `charts/shopware/templates/store.yaml` file, allowing users to set custom labels for scheduled tasks through the Helm values.