### PR TITLE
fix(shopware): omit initContainers, extraContainers, extraEnvs when not configured

### DIFF
--- a/charts/shopware/templates/store.yaml
+++ b/charts/shopware/templates/store.yaml
@@ -222,7 +222,7 @@ spec:
     replicas: {{ .Values.store.container.replicas | default 2 }}
     progressDeadlineSeconds: {{ .Values.store.container.progressDeadlineSeconds | default 30 }}
     imagePullPolicy: {{ .Values.store.container.imagePullPolicy | default "IfNotPresent" }}
-    restartPolicy: {{ .Values.store.container.imagePullPolicy | default "Always" }}
+    restartPolicy: {{ .Values.store.container.restartPolicy | default "Always" }}
     terminationGracePeriodSeconds: {{ .Values.store.container.terminationGracePeriodSeconds | default 30 }}
     volumeMounts:
       - mountPath: /etc/caddy

--- a/charts/shopware/templates/store.yaml
+++ b/charts/shopware/templates/store.yaml
@@ -267,6 +267,7 @@ spec:
           {{- toYaml . | nindent 8 }}
       {{- end }}
 
+    {{- if or .Values.store.container.initContainers (hasKey .Values.store "sidecarLogging") }}
     initContainers:
       {{- with .Values.store.container.initContainers }}
           {{- toYaml . | nindent 8 }}
@@ -316,7 +317,9 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       {{- end }}
+    {{- end }}
 
+    {{- if or .Values.store.container.extraContainers (and (hasKey .Values.store "fpm") (ne .Values.store.fpm.processManagement "dynamic")) }}
     extraContainers:
       {{- with .Values.store.container.extraContainers }}
           {{- toYaml . | nindent 8 }}
@@ -343,15 +346,16 @@ spec:
         terminationMessagePolicy: File
       {{- end }}
       {{- end }}
+    {{- end }}
 
     resources:
       {{- with .Values.store.container.resources }}
           {{- toYaml . | nindent 6 }}
       {{- end }}
+    {{- with .Values.store.container.extraEnvs }}
     extraEnvs:
-      {{- with .Values.store.container.extraEnvs }}
-          {{- toYaml . | nindent 6 }}
-      {{- end }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     volumes:
       - configMap:
           defaultMode: 420


### PR DESCRIPTION
## Problem

When `initContainers`, `extraContainers`, or `extraEnvs` are not set in values, these fields are rendered unconditionally as `null` in the `Store` CRD manifest:

```yaml
initContainers:
extraContainers:
extraEnvs:
```

The Kubernetes API server rejects this because the `Store` CRD schema declares these fields as `type: array`, and `null` is not a valid array. This causes an error on apply:

```
Store.shop.shopware.com "shopware" is invalid: [
  spec.container.initContainers: Invalid value: "null": spec.container.initContainers in body must be of type array: "null",
  spec.container.extraContainers: Invalid value: "null": spec.container.extraContainers in body must be of type array: "null"
]
```

## Fix

Wrap each field with a guard so it is only emitted when it has content:

- **`initContainers`**: only rendered when `container.initContainers` is set or `sidecarLogging` is enabled
- **`extraContainers`**: only rendered when `container.extraContainers` is set or `fpm` is configured with a non-dynamic process manager
- **`extraEnvs`**: only rendered when `container.extraEnvs` is set

The fix is a minimal, idiomatic Helm change — no helpers or logic outside `store.yaml` are required. All existing behaviour when the fields _are_ configured is preserved exactly.