### PR TITLE
fix: update fullname formatting in _helpers.tpl

### DIFF
--- a/charts/composable-frontends/Chart.yaml
+++ b/charts/composable-frontends/Chart.yaml
@@ -5,6 +5,6 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 # This value is equal to the used shopware frontends version.
 appVersion: "1.16.0"

--- a/charts/composable-frontends/templates/_helpers.tpl
+++ b/charts/composable-frontends/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{- define "composable-frontends.fullname" -}}
-{{- printf "%s-composable-frontends" .Release.Name -}}
+{{- printf .Release.Name -}}
 {{- end -}}
 
 {{- define "composable-frontends.serviceAccountName" -}}


### PR DESCRIPTION
This pull request makes a small change to the Helm template helper for naming conventions. The release name is now used directly as the full name, instead of appending `-composable-frontends`.