### PR TITLE
feat: add optional retry policy for Istio virtual service configuration

### DIFF
--- a/charts/shopware/Chart.yaml
+++ b/charts/shopware/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.59
+version: 0.0.60
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.59"
+appVersion: "0.0.60"
 
 dependencies:
   - name: pxc-operator

--- a/charts/shopware/examples/values_istio.yaml
+++ b/charts/shopware/examples/values_istio.yaml
@@ -2,6 +2,13 @@
 useIstio: true
 region: eu-central-1
 
+istio:
+  virtualService:
+    retries:
+      attempts: 3
+      perTryTimeout: 5s
+      retryOn: reset,connect-failure,refused-stream,unavailable,gateway-error,503
+
 percona:
   # You can disable Percona and use your own database. Just modify the storage database
   # part in this file.

--- a/charts/shopware/templates/istio.yaml
+++ b/charts/shopware/templates/istio.yaml
@@ -40,6 +40,10 @@ spec:
             request:
               set:
                 Host: {{ .Values.applicationName}}.{{ .Values.projectName }}.{{ .Values.organizationName }}.{{ .Values.baseDomain }}
+      {{- with .Values.istio.virtualService.retries }}
+      retries:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 ---
 apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule

--- a/charts/shopware/values.yaml
+++ b/charts/shopware/values.yaml
@@ -2,6 +2,18 @@
 # example see `examples/values_istio.yaml`.
 #useIstio: false
 
+# Istio-specific configuration. Only used when useIstio is true.
+istio:
+  virtualService:
+    # Optional retry policy applied to the store-shopware VirtualService route.
+    # Leave empty (default) to omit the retries block entirely.
+    # Example:
+    #   retries:
+    #     attempts: 3
+    #     perTryTimeout: 5s
+    #     retryOn: reset,connect-failure,refused-stream,unavailable,gateway-error,503
+    retries: {}
+
 percona:
   # You can disable Percona and use your own database. Just modify the storage database
   # part in this file.


### PR DESCRIPTION
This pull request introduces support for configuring Istio VirtualService retry policies via Helm values, making it easier to manage and customize network resilience settings for Shopware deployments. The changes add a new `istio.virtualService.retries` configuration section, update the Helm template to conditionally include retry settings, and provide documentation and examples.

Fix for https://github.com/shopware/helm-charts/issues/279

**Istio VirtualService retry policy configuration:**

* Added a new `istio.virtualService.retries` section to `values.yaml` to allow optional configuration of retry policies for the VirtualService; if left empty, retries are omitted.
* Updated the example values file (`values_istio.yaml`) to demonstrate how to set retry attempts, per-try timeout, and retry conditions.
* Modified the Istio VirtualService Helm template (`istio.yaml`) to conditionally render the `retries` block if it is set in the values, using `toYaml` for flexible configuration.