### PR TITLE
feat: allow passing extraObjects

### DIFF
--- a/charts/composable-frontends/Chart.yaml
+++ b/charts/composable-frontends/Chart.yaml
@@ -5,6 +5,6 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.1.4
 # This value is equal to the used shopware frontends version.
 appVersion: "1.16.0"

--- a/charts/composable-frontends/templates/extra-objects.yaml
+++ b/charts/composable-frontends/templates/extra-objects.yaml
@@ -1,0 +1,8 @@
+{{ range .Values.extraObjects }}
+---
+{{ if typeIs "string" . }}
+    {{- tpl . $ }}
+{{- else }}
+    {{- tpl (toYaml .) $ }}
+{{- end }}
+{{ end }}

--- a/charts/composable-frontends/values.yaml
+++ b/charts/composable-frontends/values.yaml
@@ -93,6 +93,15 @@ volumes: []
   #   emptyDir:
   #     sizeLimit: 1Gi
 
+# Array of extra Kubernetes manifests to deploy.
+extraObjects: []
+  # - apiVersion: v1
+  #   kind: ConfigMap
+  #   metadata:
+  #     name: "{{ .Release.Name }}-extra-config"
+  #   data:
+  #     example: value
+
 # HTTPRoute (gateway.networking.k8s.io/v1) configuration.
 # Annotations are propagated onto the HTTPRoute and are picked up by
 # fastly-operator (when configured) to provision the corresponding


### PR DESCRIPTION
This pull request introduces support for deploying additional custom Kubernetes manifests with the `composable-frontends` Helm chart. The main changes include adding a new `extraObjects` value, a corresponding template for rendering these objects, and a chart version bump.

**Support for extra Kubernetes manifests:**

* Added a new `extraObjects` array value in `values.yaml` to allow users to specify additional Kubernetes manifests to be deployed with the chart. This includes example usage and documentation.
* Created a new template, `extra-objects.yaml`, which iterates over `extraObjects` and renders each manifest using Helm's templating engine. This supports both string and object types for flexibility.

**Chart versioning:**

* Bumped the chart version from `0.1.3` to `0.1.4` in `Chart.yaml` to reflect the new functionality.