### PR TITLE
feat: add FrankenPHP Caddy config and skip php-fpm-exporter

### DIFF
--- a/charts/shopware/templates/store.yaml
+++ b/charts/shopware/templates/store.yaml
@@ -344,9 +344,33 @@ spec:
       {{- end }}
     {{- end }}
 
-    {{- with .Values.store.container.extraContainers }}
+    {{- if or .Values.store.container.extraContainers (and (hasKey .Values.store "fpm") (ne (default "" .Values.store.fpm.processManagement) "frankenphp") (ne (default "" .Values.store.fpm.processManagement) "dynamic")) }}
     extraContainers:
-      {{- toYaml . | nindent 8 }}
+      {{- with .Values.store.container.extraContainers }}
+          {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if hasKey .Values.store "fpm" }}
+      {{- if and (ne .Values.store.fpm.processManagement "dynamic") (ne .Values.store.fpm.processManagement "frankenphp") }}
+      - name: php-fpm-exporter
+        env:
+        - name: PHP_FPM_SCRAPE_URI
+          value: {{ .Values.store.fpm.scrapeURI | default "tcp://127.0.0.1:9000/status" }}
+        image: hipages/php-fpm_exporter
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 9253
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 30m
+            memory: 32Mi
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      {{- end }}
+      {{- end }}
     {{- end }}
 
     resources:

--- a/charts/shopware/templates/store_caddy_config.yaml
+++ b/charts/shopware/templates/store_caddy_config.yaml
@@ -5,6 +5,50 @@ metadata:
   namespace: '{{ .Release.Namespace }}'
 data:
   Caddyfile: |
+{{- if eq (default "php-fpm" .Values.store.caddy.runtime) "frankenphp" }}
+    {
+      skip_install_trust
+      admin 0.0.0.0:2019
+      frankenphp {
+        max_wait_time 3s
+      }
+      servers {
+        trusted_proxies static private_ranges
+      }
+    }
+
+    :8000 {
+      root * /var/www/html/public
+      encode zstd gzip
+
+{{- if hasKey .Values.store "sidecarLogging" }}
+      log {
+        output stdout
+        format json
+
+        output file {{ include "caddyLogPath" . }} {
+          roll_size 10MB
+          roll_keep 5
+          roll_keep_for 24h
+        }
+      }
+{{- else }}
+      log
+{{- end }}
+
+      @static {
+        path /theme/* /media/* /thumbnail/* /bundles/* /sitemap/* /favicon.ico /robots.txt
+      }
+      handle @static {
+        file_server
+      }
+
+      handle {
+        rewrite * /index.php
+        php
+      }
+    }
+{{- else }}
     {
       servers {
         timeouts {
@@ -72,3 +116,4 @@ data:
         }
       }
     }
+{{- end }}

--- a/charts/shopware/values.yaml
+++ b/charts/shopware/values.yaml
@@ -94,6 +94,10 @@ store:
   automountServiceAccountToken: false
 
   caddy:
+    # The PHP runtime mode for the Caddy web server.
+    # "php-fpm" (default): Traditional PHP-FPM with php_fastcgi directive
+    # "frankenphp": FrankenPHP with embedded PHP (uses `php` directive)
+    runtime: php-fpm
     # This is the read timeout for the caddy server. Default is 60s.
     readTimeout: 60s
     # This is the write timeout for the caddy server. Default is 60s.


### PR DESCRIPTION
- Add store.caddy.runtime value (php-fpm | frankenphp)
- Render FrankenPHP-compatible Caddyfile when runtime is 'frankenphp' (uses 'php' directive instead of php_fastcgi unix socket)
- Skip php-fpm-exporter sidecar when processManagement is 'frankenphp'
- Default remains 'php-fpm' for backward compatibility

Corresonding PR for shopware operator https://github.com/shopware/shopware-operator/pull/239